### PR TITLE
README.md: Simplify sed commands for newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Anything not working yet?
   To replace newlines and paragraphs you may use the following commands:
 
   ```
-      sed -i "s/\\\\\\\\/\n/g" slides.pdfpc
-      sed -i "s/\\\\par/\n\n/g" slides.pdfpc
+      sed -i 's/\\\\/\n/g' slides.pdfpc
+      sed -i 's/\\par/\n\n/g' slides.pdfpc
   ```
 
 Contact


### PR DESCRIPTION
By using single quotes instead of double quotes, we can omit one layer of escaping.