### PR TITLE
- changed definitions to global and \let to \edef so \lastframenumber…

### DIFF
--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -15,25 +15,32 @@
 \endgroup
 
 
-\def\lastframenumber{0}
+\global\def\lastframenumber{0}
+
 
 % define command \pnote{} that works like note but
 % additionally writes notes to file in pdfpc readable format
-\newcommand{\pnote}[1]{%
+\newcommand<>{\pnote}[2][]{%
 	% keep normal notes working
-	\note{#1}%
 
+	\note#3[#1]{#2}%
+	
 	% if frame changed - write a new header
-	\ifdim\theframenumber pt>\lastframenumber pt
-		\let\lastframenumber\theframenumber
+	\ifdim\theframenumber pt >\lastframenumber pt
+
+		\global\edef\lastframenumber{\theframenumber}
+
 		\begingroup
 			\let\#\hashchar
 			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%
 		\endgroup
-	\fi
+		
 
+	\fi
 	% write note to file
-	\immediate\write\pdfpcnotesfile{\unexpanded{#1}}%
+	% inside frame there's no point doing it twice if there's an overlay
+	\only<1>{\immediate\write\pdfpcnotesfile{\unexpanded{#2}}}%
+
 }
 % close file on \begin{document}
 \AtEndDocument{%


### PR DESCRIPTION
I hope I'm doing this right :)

… behaves correctly inside frames, with overlays and also outside of frames (i.e. that only one header is actually written per frame in all situations)

- changed \newcommand to \newcommand<> to be overlay-aware, and passed overlay to \note
- added an optional parameter to newcommand and passed it to \note to preserve \note[item] behaviour
- added an \only<1> overlay to the actual writing of the notes to file, so even with overlay around, the notes are only written once to file