### PR TITLE
Update pdfpcnotes.sty

### DIFF
--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -28,7 +28,7 @@
 		\let\lastframenumber\theframenumber
 		\begingroup
 			\let\#\hashchar
-			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%
+			\immediate\write\pdfpcnotesfile{\#\#\# \insertpagenumber}%
 		\endgroup
 	\fi
 


### PR DESCRIPTION
Changing \theframenumber to \insertpagenumber to write the correct page number when working with overlays. Additional now the notes are written multiple times if you have overlays, so you see the notes during all overlays.