### PR TITLE
Add options duration, last minutes, start and end times.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Behavior will be the same but it will additionally write notes to file in pdfpc 
 When running for example `pdflatex` you will end up with an additional `.pdfpc` file that
 will automatically be recognized by pdfpc and displays your notes nicely in the notes section on your control screen.
 
+### Options
+
+It is possible to give the following options for `\usagepackage`:
+
+* `duration=N`: Set the duration in minutes. See `--duration`
+* `lastminutes=N`: pdfpc will warn during the last N minute. See `--last-minutes`.
+* `starttime=HH:MM`: Set the start time of the presentation. See `--start-time`.
+* `endtime=HH:MM`: Set the end time of the presentation. See `--end-time`.
 
 Anything not working yet?
 -------------------------

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -1,12 +1,38 @@
 \ProvidesPackage{pdfpcnotes}
 
+% Handling of kv parameters.
+% We have the following options, that all take time in the HH:MM format
+\RequirePackage{kvoptions}
+\SetupKeyvalOptions{
+  family=PDFPC,
+  prefix=PDFPC@
+}
+\DeclareStringOption{duration}
+\DeclareStringOption{starttime}
+\DeclareStringOption{endtime}
+\DeclareStringOption{lastminutes}
+
+\ProcessKeyvalOptions*
+
+% Small macro to make inserting options easier.
+\newcommand\PDFPC@option[2]{
+  \ifx#2\@empty\else
+    \immediate\write\pdfpcnotesfile{[#1]}%
+    \immediate\write\pdfpcnotesfile{#2}%
+  \fi
+}
+
 % create a new file handle
 \newwrite\pdfpcnotesfile
 
 % open file on \begin{document}
 \AtBeginDocument{%
 	\immediate\openout\pdfpcnotesfile\jobname.pdfpc\relax
-	\immediate\write\pdfpcnotesfile{[notes]}
+ \PDFPC@option{duration}{\PDFPC@duration}
+ \PDFPC@option{start_time}{\PDFPC@starttime}
+ \PDFPC@option{end_time}{\PDFPC@endtime}
+ \PDFPC@option{last_minutes}{\PDFPC@lastminutes}
+  \immediate\write\pdfpcnotesfile{[notes]}
 }
 % define a # http://tex.stackexchange.com/a/37757/10327
 \begingroup


### PR DESCRIPTION
I used the `kvoptions` latex package, because apparently it's recommanded.
The code is quite simple. Here is the text added to the readme:


It is possible to give the following options for `\usagepackage`:

* `duration=N`: Set the duration in minutes. See `--duration`
* `lastminutes=N`: pdfpc will warn during the last N minute. See `--last-minutes`.
* `starttime=HH:MM`: Set the start time of the presentation. See `--start-time`.
* `endtime=HH:MM`: Set the end time of the presentation. See `--end-time`.