### PR TITLE
A few changes and improvements

### DIFF
--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -3,6 +3,9 @@
 	{pdfpcnotes}%
 	[2016/05/04 \space ver 0.2 \space To generate notes to use with pdfpc]
 
+\RequirePackage{forloop}
+\RequirePackage{pdftexcmds}
+
 \RequirePackage{kvoptions}
 \DeclareStringOption{fontsize}[32130]
 \ProcessKeyvalOptions*\relax
@@ -28,7 +31,10 @@
 \endgroup
 
 
-\global\def\lastframenumber{0}
+\global\def\pdfpcnotes@lastframenumber{0}
+\newcounter{pdfpcnotes@currentframenotes}
+\newcounter{pdfpcnotes@checkifnoteexists}
+\newif\ifpdfpcnotes@noteexists
 
 % define command \pnote{} that works like note but
 % additionally writes notes to file in pdfpc readable format
@@ -37,16 +43,37 @@
 	\note{#1}%
 
 	% if frame changed - write a new header
-	\ifdim\theframenumber pt>\lastframenumber pt
-		\global\edef\lastframenumber{\theframenumber}
+	\ifdim\theframenumber pt>\pdfpcnotes@lastframenumber pt
+		\global\edef\pdfpcnotes@lastframenumber{\theframenumber}
+		\setcounter{pdfpcnotes@currentframenotes}{0}
 		\begingroup
 			\let\#\hashchar
 			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%
 		\endgroup
 	\fi
 
-	% write note to file
-	\immediate\write\pdfpcnotesfile{\unexpanded{#1}}%
+	% check if note was already stored
+	\pdfpcnotes@noteexistsfalse
+	\forloop{pdfpcnotes@checkifnoteexists}{0}{%
+		\value{pdfpcnotes@checkifnoteexists} < \value{pdfpcnotes@currentframenotes}%
+	}{
+		\ifnum\pdf@strcmp{\unexpanded{#1}}{\csname pdfpcnotes@currentframenotes@\thepdfpcnotes@checkifnoteexists\endcsname}=0
+			\pdfpcnotes@noteexiststrue
+			\setcounter{pdfpcnotes@checkifnoteexists}{\value{pdfpcnotes@currentframenotes}}
+		\else
+		\fi
+	}
+
+	% and then, only if the note was not stored
+	\ifpdfpcnotes@noteexists
+	\else
+		% add note in stored notes
+		\expandafter\global\expandafter\def\csname pdfpcnotes@currentframenotes@\thepdfpcnotes@currentframenotes\endcsname{\unexpanded{#1}}%
+		\stepcounter{pdfpcnotes@currentframenotes}%
+
+		% write note to file
+		\immediate\write\pdfpcnotesfile{\unexpanded{#1}}%
+	\fi
 }
 % close file on \begin{document}
 \AtEndDocument{%

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -1,3 +1,14 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% pdfpcnotes.sty
+%
+% Create notes for PDFPC from a beamer file
+%
+% Copyright 2013       Carsten Brandt <mail@cebe.cc>
+% Copyright 2013       Aggelos Karalias <aggelos.karalias@gmail.com>
+% Copyright 2014-2016  Raphaël Beamonte <raphael.beamonte@gmail.com>
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \ProvidesPackage%
 	{pdfpcnotes}%

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -1,3 +1,4 @@
+
 \ProvidesPackage{pdfpcnotes}
 
 % create a new file handle
@@ -15,7 +16,7 @@
 \endgroup
 
 
-\def\lastframenumber{0}
+\global\def\lastframenumber{0}
 
 % define command \pnote{} that works like note but
 % additionally writes notes to file in pdfpc readable format
@@ -25,7 +26,7 @@
 
 	% if frame changed - write a new header
 	\ifdim\theframenumber pt>\lastframenumber pt
-		\let\lastframenumber\theframenumber
+		\global\edef\lastframenumber{\theframenumber}
 		\begingroup
 			\let\#\hashchar
 			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -1,5 +1,11 @@
 
-\ProvidesPackage{pdfpcnotes}
+\ProvidesPackage%
+	{pdfpcnotes}%
+	[2016/05/04 \space ver 0.2 \space To generate notes to use with pdfpc]
+
+\RequirePackage{kvoptions}
+\DeclareStringOption{fontsize}[32130]
+\ProcessKeyvalOptions*\relax
 
 % create a new file handle
 \newwrite\pdfpcnotesfile
@@ -7,6 +13,12 @@
 % open file on \begin{document}
 \AtBeginDocument{%
 	\immediate\openout\pdfpcnotesfile\jobname.pdfpc\relax
+	\immediate\write\pdfpcnotesfile{[file]}
+	\immediate\write\pdfpcnotesfile{\jobname.pdf}
+	\ifx\pdfpcnotes@fontsize\@empty
+	\else
+		\immediate\write\pdfpcnotesfile{[font_size]^^J\pdfpcnotes@fontsize}
+	\fi
 	\immediate\write\pdfpcnotesfile{[notes]}
 }
 % define a # http://tex.stackexchange.com/a/37757/10327

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -72,7 +72,11 @@
 		\stepcounter{pdfpcnotes@currentframenotes}%
 
 		% write note to file
-		\immediate\write\pdfpcnotesfile{\unexpanded{#1}}%
+		\begingroup
+			\def\\{^^J}
+			\def\par{^^J^^J}
+			\immediate\write\pdfpcnotesfile{#1}%
+		\endgroup
 	\fi
 }
 % close file on \begin{document}

--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -52,46 +52,45 @@
 \newcommand{\pnote}[1]{%
 	% keep normal notes working
 	\note{#1}%
-
+%
 	% if frame changed - write a new header
 	\ifdim\theframenumber pt>\pdfpcnotes@lastframenumber pt
-		\global\edef\pdfpcnotes@lastframenumber{\theframenumber}
-		\setcounter{pdfpcnotes@currentframenotes}{0}
-		\begingroup
-			\let\#\hashchar
+		\global\edef\pdfpcnotes@lastframenumber{\theframenumber}%
+		\setcounter{pdfpcnotes@currentframenotes}{0}%
+		\begingroup%
+			\let\#\hashchar%
 			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%
-		\endgroup
-	\fi
-
+		\endgroup%
+	\fi%
+%
 	% check if note was already stored
-	\pdfpcnotes@noteexistsfalse
+	\pdfpcnotes@noteexistsfalse%
 	\forloop{pdfpcnotes@checkifnoteexists}{0}{%
 		\value{pdfpcnotes@checkifnoteexists} < \value{pdfpcnotes@currentframenotes}%
-	}{
+	}{%
 		\ifnum\pdf@strcmp{\unexpanded{#1}}{\csname pdfpcnotes@currentframenotes@\thepdfpcnotes@checkifnoteexists\endcsname}=0
-			\pdfpcnotes@noteexiststrue
-			\setcounter{pdfpcnotes@checkifnoteexists}{\value{pdfpcnotes@currentframenotes}}
-		\else
-		\fi
-	}
-
+			\pdfpcnotes@noteexiststrue%
+			\setcounter{pdfpcnotes@checkifnoteexists}{\value{pdfpcnotes@currentframenotes}}%
+		\else%
+		\fi%
+	}%
+%
 	% and then, only if the note was not stored
-	\ifpdfpcnotes@noteexists
-	\else
+	\ifpdfpcnotes@noteexists%
+	\else%
 		% add note in stored notes
 		\expandafter\global\expandafter\def\csname pdfpcnotes@currentframenotes@\thepdfpcnotes@currentframenotes\endcsname{\unexpanded{#1}}%
 		\stepcounter{pdfpcnotes@currentframenotes}%
-
+%
 		% write note to file
-		\begingroup
-			\def\\{^^J}
-			\def\par{^^J^^J}
+		\begingroup%
+			\def\\{^^J}%
+			\def\par{^^J^^J}%
 			\immediate\write\pdfpcnotesfile{#1}%
-		\endgroup
-	\fi
+		\endgroup%
+	\fi%
 }
 % close file on \begin{document}
 \AtEndDocument{%
 	\immediate\closeout\pdfpcnotesfile
 }
-


### PR DESCRIPTION
Those commits allow to fix a number of different problems that I found using pdfpc-latex-notes. Moreover, some new features are provided, such as managing the font size of the notes as a package option (not to have to edit the generated pdfpc file each time) and managing the use for \\ and \par in notes without needing to use a sed in the generated pdfpc file.