### PR TITLE
allows pnote to pass [item] command to note

### DIFF
--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -45,11 +45,12 @@
 
 \def\lastframenumber{0}
 
-% define command \pnote{} that works like note but
+% define command \pnote[]{} that works like note but
 % additionally writes notes to file in pdfpc readable format
-\newcommand{\pnote}[1]{%
+% pnote will pass any optional arguments [] directly to note, e.g. \pnote[item]{}
+\newcommand{\pnote}[2][]{%
 	% keep normal notes working
-	\note{#1}%
+	\note[#1]{#2}%
 
 	% if frame changed - write a new header
 	\ifdim\theframenumber pt>\lastframenumber pt
@@ -61,7 +62,7 @@
 	\fi
 
 	% write note to file
-	\immediate\write\pdfpcnotesfile{\unexpanded{#1}}%
+	\immediate\write\pdfpcnotesfile{\unexpanded{#2}}%
 }
 % close file on \begin{document}
 \AtEndDocument{%


### PR DESCRIPTION
Partial solution to #13 
Note that this change only works when using pnote inside a frame
The result is itemized for \setbeameroption{show notes} and \setbeameroption{show only notes} but will just appear as unitemized paragraphs in pdfpc
This will need to be updated when pnote is modified to work a) outside of frame and b) respect itemize and enumerate within pdfpc