### PR TITLE
Fixed page counting

### DIFF
--- a/pdfpcnotes.sty
+++ b/pdfpcnotes.sty
@@ -52,11 +52,11 @@
 	\note{#1}%
 
 	% if frame changed - write a new header
-	\ifdim\theframenumber pt>\lastframenumber pt
-		\let\lastframenumber\theframenumber
+	\ifdim\thepage pt>\lastframenumber pt
+		\let\lastframenumber\thepage
 		\begingroup
 			\let\#\hashchar
-			\immediate\write\pdfpcnotesfile{\#\#\# \theframenumber}%
+			\immediate\write\pdfpcnotesfile{\#\#\# \thepage}%
 		\endgroup
 	\fi
 


### PR DESCRIPTION
When using animations `\theframenumber` will emit the theoretical page number, not counting slides for animation. I fixed it by using `\thepage` instead.

This is related to #21